### PR TITLE
Fix: 09-数据类型转换.md parseInt会忽略开头空格

### DIFF
--- a/04-JavaScript基础/09-数据类型转换.md
+++ b/04-JavaScript基础/09-数据类型转换.md
@@ -303,7 +303,7 @@ Number() 函数和 parseInt() 函数的区别：
 
 -   Number(true) ：千方百计地想转换为数字；如果转换不了则返回 NaN。
 
--   parseInt(true)/parseFloat(true) ：提取出最前面的数字部分；没提取出来，那就返回 NaN。
+-   parseInt(true)/parseFloat(true) ：提取出最前面的数字部分(开头如果是空格，自动忽略)；没提取出来，那就返回 NaN。
 
 **parseInt()具有以下特性**：
 


### PR DESCRIPTION
parseInt 会忽略字符串开头的空格，取后面的数字。